### PR TITLE
Check code for issues

### DIFF
--- a/GoogleDriveService.js
+++ b/GoogleDriveService.js
@@ -1508,7 +1508,7 @@ console.log(isFileView);
                         responseType: "blob"
                     }).success(function (data, status, headers, config) {
                         if (data !== undefined) {
-                            if (resp.fileExtension.indexOf(".$enc") > -1) {
+                            if (fName.indexOf(".$enc") > -1) {
                                 var cFName = fName.replace(".$enc", "");
                                 utilsService
                                     .decryptFileObject(data, authService.activeSession.encr_key, fExt)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes double encryption of files during batch operations and enables sharing of multiple selected files via email.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The encrypt/decrypt issue stemmed from `GoogleDriveService.js` incorrectly checking `resp.fileExtension` instead of the full filename (`fName`) for the `.$enc` suffix in the `encryptDecryptSynchronized` function, causing already encrypted files to be re-encrypted. The multiple file sharing issue was due to the `CloudsController.js` only processing a single file for email sharing, even when multiple files were selected. This PR introduces logic to iterate through all selected files, generate their share URLs, and include them in a single email.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a6a3de1-f3a1-4770-b0cf-ffe2e436012f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a6a3de1-f3a1-4770-b0cf-ffe2e436012f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>